### PR TITLE
カード上端のカラーを納期までの日数に合わせて変化させる

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2290,7 +2290,7 @@ dependencies = [
 
 [[package]]
 name = "neko_todo"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "bcrypt",
  "chrono",

--- a/src/TodoList.jsx
+++ b/src/TodoList.jsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { Grid, GridItem, HStack, IconButton, Switch, Text} from "@yamada-ui/react";
+import { Container, Grid, GridItem, HStack, IconButton, Switch } from "@yamada-ui/react";
 import { invoke } from "@tauri-apps/api/core";
 import { AiOutlineFileAdd } from "react-icons/ai";
 import { useState } from "react";
@@ -39,23 +39,25 @@ function TodoList() {
     console.log(todos);
     return (
         <>
-            <HStack>
-                <IconButton icon={<AiOutlineFileAdd/>} onClick={handleAddTodo}/>
-                <Switch checked={IsIncomplete} onChange={onIsIncompleteChange}>
-                    未完了のみ
-                </Switch>
-            </HStack>
+            <Container gap="0" bg="backgound">
+                <HStack>
+                    <IconButton icon={<AiOutlineFileAdd/>} onClick={handleAddTodo}/>
+                    <Switch checked={IsIncomplete} onChange={onIsIncompleteChange}>
+                        未完了のみ
+                    </Switch>
+                </HStack>
 
-            <h1>現在の予定</h1>
-            <Grid templateColumns="repeat(4, 1fr)" gap="md">
-                {todos?.map( todo_item => {
-                    return (
-                        <GridItem key={todo_item.id} w="full" rounded="md" bg="primary">
-                            <TodoItem item={todo_item}/>
-                        </GridItem>
+                <h1>現在の予定</h1>
+                <Grid templateColumns="repeat(4, 1fr)" gap="md" >
+                    {todos?.map( todo_item => {
+                        return (
+                            <GridItem key={todo_item.id} w="full" rounded="md" bg="primary">
+                                <TodoItem item={todo_item}/>
+                            </GridItem>
+                        )}
                     )}
-                )}
-            </Grid>
+                </Grid>
+            </Container>
         </>
     );
 }

--- a/src/theme/index.jsx
+++ b/src/theme/index.jsx
@@ -1,8 +1,10 @@
 import { extendTheme } from "@yamada-ui/react";
 import { styles } from "./styles";
+import { semantics } from "./semantics";
 
 const custumTheme = { 
     styles,
+    semantics,
 }
 
 export const theme = extendTheme(custumTheme)()

--- a/src/theme/semantics.ts
+++ b/src/theme/semantics.ts
@@ -1,0 +1,7 @@
+import { ThemeSemantics } from "@yamada-ui/react";
+
+export const semantics: ThemeSemantics = {
+    colors: {
+        backgound: "#DCB879",
+    }
+}

--- a/src/theme/styles/globalStyle.jsx
+++ b/src/theme/styles/globalStyle.jsx
@@ -1,6 +1,6 @@
 export const globalStyle = {
     body: {
-        bg: ["#DCB879"],
+        bg: ["backgound"],
         height: "100vh",
     },
 }

--- a/src/todoitem.jsx
+++ b/src/todoitem.jsx
@@ -2,7 +2,7 @@
 import {useNavigate} from "react-router-dom";
 import {useMutation, useQueryClient} from "@tanstack/react-query";
 import {invoke} from "@tauri-apps/api/core";
-import { SimpleGrid, GridItem, IconButton, Text, HStack } from "@yamada-ui/react";
+import { SimpleGrid, GridItem, IconButton, Text, HStack, Container } from "@yamada-ui/react";
 import { GrWorkshop } from "react-icons/gr";
 import { BsAlarm } from "react-icons/bs";
 import { BsEmojiGrin } from "react-icons/bs";
@@ -52,14 +52,31 @@ export default function TodoItem({item}) {
         done_icon = <GrWorkshop/>
     }
 
+    // 上部バーの背景色
+    const oneday = 24 * 60 * 60 * 1000;
+    const today = new Date();
+    const delivery = new Date(item.end_date);
+    const daysToDelivery = (delivery - today) / oneday;
+    let line_color;
+    if (daysToDelivery < 0) {
+        line_color = "danger";
+    } else if (daysToDelivery < 2) {
+        line_color = "warning";
+    } else {
+        line_color = "success";
+    }
+
     return (
-        <>
-            <SimpleGrid w="full" columns={{base: 2, md: 1}} gap="md">
+        <Container p="1%" gap="0">
+            <SimpleGrid w="full" columns={{base: 2, md: 1}} gap="md" bg={line_color}>
                 <GridItem> 
                     <HStack>
-                        <IconButton size="xs" icon={done_icon} onClick={onDoneClick}/>  
-                        <IconButton size="xs" icon={<BiPencil/>} onClick={onEditClick}/>
-                        <IconButton size="xs" icon={<FaRegCopy/>} onClick={onPasteClick}/>
+                        <IconButton size="xs" icon={done_icon} onClick={onDoneClick} 
+                            bg={line_color}/>  
+                        <IconButton size="xs" icon={<BiPencil/>} onClick={onEditClick} 
+                            bg={line_color}/>
+                        <IconButton size="xs" icon={<FaRegCopy/>} onClick={onPasteClick} 
+                            bg={line_color}/>
                     </HStack>
                 </GridItem>
                 
@@ -78,7 +95,7 @@ export default function TodoItem({item}) {
             <Text fontSize="sm">
                 {start_date?.toLocaleDateString()} 〜 {end_date?.toLocaleDateString()}
             </Text>
-        </>
+        </Container>
     );
 }
 


### PR DESCRIPTION
- カード上端カラー変更モード追加
- バックグランドの調整(スクロールしたとき下端に「白」が出るのを消去)
- セマンティックストークン backgroud を追加
- versionナンバー更新

fixed #8
